### PR TITLE
Gos REV lib

### DIFF
--- a/GirlsOfSteelLibRev/build.gradle
+++ b/GirlsOfSteelLibRev/build.gradle
@@ -1,0 +1,20 @@
+plugins {
+    id "java"
+    id "edu.wpi.first.GradleRIO" version "2023.4.3"
+}
+
+sourceCompatibility = JavaVersion.VERSION_11
+targetCompatibility = JavaVersion.VERSION_11
+
+dependencies {
+    implementation wpi.java.deps.wpilib()
+    implementation wpi.java.vendor.java()
+    implementation project(":libraries:GirlsOfSteelLib")
+}
+
+test {
+    useJUnitPlatform()
+}
+
+ext.groupId = "com.gos.lib.rev"
+apply from: "${rootDir}/build_scripts/gradle/publish_java.gradle"

--- a/GirlsOfSteelLibRev/src/main/java/com/gos/lib/rev/BUILD.bazel
+++ b/GirlsOfSteelLibRev/src/main/java/com/gos/lib/rev/BUILD.bazel
@@ -1,0 +1,13 @@
+load("//build_scripts/bazel:java_rules.bzl", "gos_java_library")
+
+gos_java_library(
+    name = "rev",
+    srcs = glob(["*.java"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//libraries/GirlsOfSteelLib/src/main/java/com/gos/lib/properties",
+        "//libraries/GirlsOfSteelLib/src/main/java/org/littletonrobotics/frc2023/util:mechanical_advantage",
+        "@bazelrio//libraries/java/rev/revlib",
+        "@bazelrio//libraries/java/wpilib/wpilibj",
+    ],
+)

--- a/GirlsOfSteelLibRev/src/main/java/com/gos/lib/rev/RevPidPropertyBuilder.java
+++ b/GirlsOfSteelLibRev/src/main/java/com/gos/lib/rev/RevPidPropertyBuilder.java
@@ -1,0 +1,52 @@
+package com.gos.lib.rev;
+
+import com.gos.lib.properties.IPidPropertyBuilder;
+import com.gos.lib.properties.PidProperty;
+import com.revrobotics.SparkMaxPIDController;
+
+public final class RevPidPropertyBuilder extends PidProperty.Builder implements IPidPropertyBuilder {
+    private final SparkMaxPIDController m_pidController;
+    private final int m_slot;
+
+    public RevPidPropertyBuilder(String baseName, boolean isConstant, SparkMaxPIDController pidController, int slot) {
+        super(baseName, isConstant);
+        m_pidController = pidController;
+        m_slot = slot;
+    }
+
+    @Override
+    public IPidPropertyBuilder addP(double defaultValue) {
+        addP(defaultValue, (double gain) -> m_pidController.setP(gain, m_slot));
+        return this;
+    }
+
+    @Override
+    public IPidPropertyBuilder addI(double defaultValue) {
+        addI(defaultValue, (double gain) -> m_pidController.setI(gain, m_slot));
+        return this;
+    }
+
+    @Override
+    public IPidPropertyBuilder addD(double defaultValue) {
+        addD(defaultValue, (double gain) -> m_pidController.setD(gain, m_slot));
+        return this;
+    }
+
+    @Override
+    public IPidPropertyBuilder addFF(double defaultValue) {
+        addFF(defaultValue, (double gain) -> m_pidController.setFF(gain, m_slot));
+        return this;
+    }
+
+    @Override
+    public IPidPropertyBuilder addMaxVelocity(double defaultValue) {
+        addMaxVelocity(defaultValue, (double gain) -> m_pidController.setSmartMotionMaxVelocity(gain, m_slot));
+        return this;
+    }
+
+    @Override
+    public IPidPropertyBuilder addMaxAcceleration(double defaultValue) {
+        addMaxAcceleration(defaultValue, (double gain) -> m_pidController.setSmartMotionMaxAccel(gain, m_slot));
+        return this;
+    }
+}

--- a/GirlsOfSteelLibRev/src/main/java/com/gos/lib/rev/SparkMaxAlerts.java
+++ b/GirlsOfSteelLibRev/src/main/java/com/gos/lib/rev/SparkMaxAlerts.java
@@ -1,0 +1,57 @@
+package com.gos.lib.rev;
+
+import com.revrobotics.CANSparkMax;
+import org.littletonrobotics.frc2023.util.Alert;
+
+public class SparkMaxAlerts {
+    public final CANSparkMax m_sparkMax;
+    public final String m_motorString;
+    public final Alert m_alert;
+    public final Alert m_alertSticky;
+
+    public SparkMaxAlerts(CANSparkMax sparkMax, String motor) {
+        m_sparkMax = sparkMax;
+        m_motorString = motor;
+        m_alert = new Alert(m_motorString, Alert.AlertType.ERROR);
+        m_alertSticky = new Alert(m_motorString, Alert.AlertType.WARNING);
+    }
+
+    public void checkAlerts() {
+        checkFaults();
+        checkStickyFaults();
+    }
+
+    private void checkFaults() {
+        short bitmask = m_sparkMax.getFaults();
+
+        StringBuilder errorBuilder = new StringBuilder(m_motorString);
+        for (CANSparkMax.FaultID faultId : CANSparkMax.FaultID.values()) {
+            if ((bitmask & (1 << faultId.value)) != 0) {
+                errorBuilder.append('\n').append(faultId);
+            }
+        }
+
+        String errorString = errorBuilder.toString();
+        m_alert.setText(errorString);
+
+        m_alert.set(!(errorString.equals(m_motorString)));
+    }
+
+    private void checkStickyFaults() {
+        short bitmask = m_sparkMax.getStickyFaults();
+
+        StringBuilder errorBuilder = new StringBuilder(m_motorString);
+        for (CANSparkMax.FaultID faultId : CANSparkMax.FaultID.values()) {
+            if ((bitmask & (1 << faultId.value)) != 0) {
+                errorBuilder.append('\n').append(faultId);
+            }
+        }
+
+        String errorString = errorBuilder.toString();
+        m_alertSticky.setText(errorString);
+
+        m_alertSticky.set(!(errorString.equals(m_motorString)));
+
+
+    }
+}

--- a/GirlsOfSteelLibRev/src/main/java/com/gos/lib/rev/SparkMaxUtil.java
+++ b/GirlsOfSteelLibRev/src/main/java/com/gos/lib/rev/SparkMaxUtil.java
@@ -1,0 +1,39 @@
+package com.gos.lib.rev;
+
+import com.revrobotics.REVLibError;
+import edu.wpi.first.wpilibj.DriverStation;
+import org.littletonrobotics.frc2023.util.Alert;
+
+import java.util.function.Supplier;
+
+public class SparkMaxUtil {
+
+    private static final StringBuilder ALERT_BUILDER = new StringBuilder(100); // NOPMD(AvoidStringBufferField)
+    private static final Alert CONFIG_FAILED_ALERT = new Alert("Rev CAN config failure", Alert.AlertType.ERROR);
+    private static boolean configFailed;
+
+    public static void autoRetry(Supplier<REVLibError> command) {
+        autoRetry(command, 10);
+    }
+
+    public static void autoRetry(Supplier<REVLibError> command, int maxRetries) {
+        int ctr = 0;
+        REVLibError error;
+
+        do {
+            error = command.get();
+            ++ctr;
+        }
+        while (error != REVLibError.kOk && ctr < maxRetries);
+
+        configFailed &= error != REVLibError.kOk;
+
+        if (ctr != 1) {
+            ALERT_BUILDER.append("Took ").append(ctr).append(" times to retry command");
+            DriverStation.reportError("Took " + ctr + " times to retry command", false);
+        }
+
+        CONFIG_FAILED_ALERT.set(configFailed);
+        CONFIG_FAILED_ALERT.setText(ALERT_BUILDER.toString());
+    }
+}

--- a/GirlsOfSteelLibRev/src/main/java/com/gos/lib/rev/checklists/BUILD.bazel
+++ b/GirlsOfSteelLibRev/src/main/java/com/gos/lib/rev/checklists/BUILD.bazel
@@ -1,0 +1,13 @@
+load("//build_scripts/bazel:java_rules.bzl", "gos_java_library")
+
+gos_java_library(
+    name = "checklists",
+    srcs = glob(["*.java"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//libraries/GirlsOfSteelLib/src/main/java/org/littletonrobotics/frc2023/util:mechanical_advantage",
+        "@bazelrio//libraries/java/rev/revlib",
+        "@bazelrio//libraries/java/wpilib/new_commands",
+        "@bazelrio//libraries/java/wpilib/wpilibj",
+    ],
+)

--- a/GirlsOfSteelLibRev/src/main/java/com/gos/lib/rev/checklists/SparkMaxMotorsMoveChecklist.java
+++ b/GirlsOfSteelLibRev/src/main/java/com/gos/lib/rev/checklists/SparkMaxMotorsMoveChecklist.java
@@ -1,0 +1,64 @@
+package com.gos.lib.rev.checklists;
+
+
+import com.revrobotics.CANSparkMax;
+import com.revrobotics.RelativeEncoder;
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import edu.wpi.first.wpilibj2.command.Subsystem;
+import org.littletonrobotics.frc2023.util.Alert;
+
+public class SparkMaxMotorsMoveChecklist extends CommandBase {
+
+    private final RelativeEncoder m_encoder;
+
+    private final CANSparkMax m_motor;
+
+    private final Timer m_timer;
+
+    private double m_startPosMotor;
+
+    private final String m_label;
+
+    private final double m_expectedDist;
+
+    private final Alert m_alert;
+
+    public SparkMaxMotorsMoveChecklist(Subsystem subsystem, CANSparkMax motor, String label, double expectedDist) {
+        addRequirements(subsystem);
+        m_encoder = motor.getEncoder();
+        m_motor = motor;
+        m_startPosMotor = 0;
+        m_timer = new Timer();
+        m_label = label;
+        m_expectedDist = expectedDist;
+        m_alert = new Alert(m_label, Alert.AlertType.ERROR);
+
+    }
+
+    @Override
+    public void initialize() {
+        m_motor.set(0);
+        m_startPosMotor = m_encoder.getPosition();
+        m_timer.reset();
+        m_timer.start();
+    }
+
+    @Override
+    public void execute() {
+        m_motor.set(0.25);
+    }
+
+    @Override
+    public boolean isFinished() {
+        return (m_timer.get() >= 1);
+    }
+
+    @Override
+    public void end(boolean interrupted) {
+        m_motor.set(0);
+        boolean isRobotAtPos = m_encoder.getPosition() - m_startPosMotor >= m_expectedDist;
+        m_alert.set(!isRobotAtPos);
+        m_timer.stop();
+    }
+}

--- a/GirlsOfSteelLibRev/vendordeps/REVLib.json
+++ b/GirlsOfSteelLibRev/vendordeps/REVLib.json
@@ -1,0 +1,73 @@
+{
+    "fileName": "REVLib.json",
+    "name": "REVLib",
+    "version": "2023.1.3",
+    "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
+    "mavenUrls": [
+        "https://maven.revrobotics.com/"
+    ],
+    "jsonUrl": "https://software-metadata.revrobotics.com/REVLib-2023.json",
+    "javaDependencies": [
+        {
+            "groupId": "com.revrobotics.frc",
+            "artifactId": "REVLib-java",
+            "version": "2023.1.3"
+        }
+    ],
+    "jniDependencies": [
+        {
+            "groupId": "com.revrobotics.frc",
+            "artifactId": "REVLib-driver",
+            "version": "2023.1.3",
+            "skipInvalidPlatforms": true,
+            "isJar": false,
+            "validPlatforms": [
+                "windowsx86-64",
+                "windowsx86",
+                "linuxarm64",
+                "linuxx86-64",
+                "linuxathena",
+                "linuxarm32",
+                "osxuniversal"
+            ]
+        }
+    ],
+    "cppDependencies": [
+        {
+            "groupId": "com.revrobotics.frc",
+            "artifactId": "REVLib-cpp",
+            "version": "2023.1.3",
+            "libName": "REVLib",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "windowsx86",
+                "linuxarm64",
+                "linuxx86-64",
+                "linuxathena",
+                "linuxarm32",
+                "osxuniversal"
+            ]
+        },
+        {
+            "groupId": "com.revrobotics.frc",
+            "artifactId": "REVLib-driver",
+            "version": "2023.1.3",
+            "libName": "REVLibDriver",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "windowsx86",
+                "linuxarm64",
+                "linuxx86-64",
+                "linuxathena",
+                "linuxarm32",
+                "osxuniversal"
+            ]
+        }
+    ]
+}

--- a/GirlsOfSteelLibRev/vendordeps/WPILibNewCommands.json
+++ b/GirlsOfSteelLibRev/vendordeps/WPILibNewCommands.json
@@ -1,0 +1,37 @@
+{
+  "fileName": "WPILibNewCommands.json",
+  "name": "WPILib-New-Commands",
+  "version": "1.0.0",
+  "uuid": "111e20f7-815e-48f8-9dd6-e675ce75b266",
+  "mavenUrls": [],
+  "jsonUrl": "",
+  "javaDependencies": [
+      {
+          "groupId": "edu.wpi.first.wpilibNewCommands",
+          "artifactId": "wpilibNewCommands-java",
+          "version": "wpilib"
+      }
+  ],
+  "jniDependencies": [],
+  "cppDependencies": [
+      {
+          "groupId": "edu.wpi.first.wpilibNewCommands",
+          "artifactId": "wpilibNewCommands-cpp",
+          "version": "wpilib",
+          "libName": "wpilibNewCommands",
+          "headerClassifier": "headers",
+          "sourcesClassifier": "sources",
+          "sharedLibrary": true,
+          "skipInvalidPlatforms": true,
+          "binaryPlatforms": [
+              "linuxathena",
+              "linuxraspbian",
+              "linuxaarch64bionic",
+              "windowsx86-64",
+              "windowsx86",
+              "linuxx86-64",
+              "osxx86-64"
+          ]
+      }
+  ]
+}


### PR DESCRIPTION
Contains our REV specific reusable library. Available as a vendordep!

This is mostly just rev-specific versions of the stuff in our common library, so you only have to include these if you are using rev products and can ignore if you are using ctre